### PR TITLE
Add support to display B28, B32 and B38 bands on MF289F modem

### DIFF
--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo-addon/19d21432
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo-addon/19d21432
@@ -55,6 +55,9 @@ case "$MODE_NUM" in
                         *"LTE B7") MODE=$(band 7 "LTE ");;
                         *"LTE B8") MODE=$(band 8 "LTE ");;
                         *"LTE B20") MODE=$(band 20 "LTE ");;
+                        *"LTE B28") MODE=$(band 28 "LTE ");;
+                        *"LTE B32") MODE=$(band 32 "LTE ");;
+                        *"LTE B38") MODE=$(band 38 "LTE ");;			
                         *) MODE="${T}";;
                 esac
                 T=$(echo "$O" | awk -F$AWK_FILTER '/^\+ZCAINFO/ {print $9}' | xargs)
@@ -66,6 +69,9 @@ case "$MODE_NUM" in
                                 *"7") MODE="${MODE/LTE/LTE_A} / "$(band 7 "");;
                                 *"8") MODE="${MODE/LTE/LTE_A} / "$(band 8 "");;
                                 *"20") MODE="${MODE/LTE/LTE_A} / "$(band 20 "");;
+                                *"28") MODE="${MODE/LTE/LTE_A} / "$(band 28 "");;
+                                *"32") MODE="${MODE/LTE/LTE_A} / "$(band 32 "");;
+                                *"38") MODE="${MODE/LTE/LTE_A} / "$(band 38 "");;				
                                 *) MODE="${MODE/LTE/LTE_A} / B${T}";;
                         esac
                         T=$(echo "$O" | awk -F[,:\;] '/^\+ZCAINFO/ {print $14}' | xargs)
@@ -76,6 +82,9 @@ case "$MODE_NUM" in
                                         *"7") MODE="$MODE / "$(band 7 "");;
                                         *"8") MODE="$MODE / "$(band 8 "");;
                                         *"20") MODE="$MODE / "$(band 20 "");;
+                                        *"28") MODE="$MODE / "$(band 28 "");;
+                                        *"32") MODE="$MODE / "$(band 32 "");;
+                                        *"38") MODE="$MODE / "$(band 38 "");;					
                                         *) MODE="$MODE / B${T}";;
                                 esac
                                 MODE=$(echo $MODE | sed "s/LTE_A/LTE-A |/g" | sed 's,/,+,')
@@ -88,6 +97,9 @@ case "$MODE_NUM" in
                                         *"7") MODE="$MODE / "$(band 7 "");;
                                         *"8") MODE="$MODE / "$(band 8 "");;
                                         *"20") MODE="$MODE / "$(band 20 "");;
+                                        *"28") MODE="$MODE / "$(band 28 "");;
+                                        *"32") MODE="$MODE / "$(band 32 "");;
+                                        *"38") MODE="$MODE / "$(band 38 "");;						
                                         *) MODE="$MODE / B${T}";;
                                 esac
                          	 MODE=$(echo $MODE)

--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo-addon/19d21485
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo-addon/19d21485
@@ -106,6 +106,9 @@ case "$MODE_NUM" in
 				*"7") MODE="${MODE/LTE/LTE_A} / "$(band 7 "");;
 				*"8") MODE="${MODE/LTE/LTE_A} / "$(band 8 "");;
 				*"20") MODE="${MODE/LTE/LTE_A} / "$(band 20 "");;
+				*"28") MODE="${MODE/LTE/LTE_A} / "$(band 28 "");;
+				*"32") MODE="${MODE/LTE/LTE_A} / "$(band 32 "");;
+				*"38") MODE="${MODE/LTE/LTE_A} / "$(band 38 "");;				
 				*) MODE="${MODE/LTE/LTE_A} / B${T}";;
 			esac
 			T=$(echo "$O" | awk -F[,:\;] '/^\+ZCAINFO/ {print $14}' | xargs)
@@ -131,6 +134,9 @@ case "$MODE_NUM" in
 					*"7") MODE="$MODE / "$(band 7 "");;
 					*"8") MODE="$MODE / "$(band 8 "");;
 					*"20") MODE="$MODE / "$(band 20 "");;
+					*"28") MODE="$MODE / "$(band 28 "");;
+					*"32") MODE="$MODE / "$(band 32 "");;
+					*"38") MODE="$MODE / "$(band 38 "");;					
 					*) MODE="$MODE / B${T}";;
 				esac
 			fi

--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo-addon/19d21485
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo-addon/19d21485
@@ -93,6 +93,9 @@ case "$MODE_NUM" in
 			*"LTE B7") MODE=$(band 7 "LTE ");;
 			*"LTE B8") MODE=$(band 8 "LTE ");;
 			*"LTE B20") MODE=$(band 20 "LTE ");;
+			*"LTE B28") MODE=$(band 28 "LTE ");;
+			*"LTE B32") MODE=$(band 32 "LTE ");;
+			*"LTE B38") MODE=$(band 38 "LTE ");;
 			*) MODE="$T";;
 		esac
 		T=$(echo "$O" | awk -F[,:\;] '/^\+ZCAINFO/ {print $9}' | xargs)
@@ -113,6 +116,9 @@ case "$MODE_NUM" in
 					*"7") MODE="$MODE / "$(band 7 "");;
 					*"8") MODE="$MODE / "$(band 8 "");;
 					*"20") MODE="$MODE / "$(band 20 "");;
+					*"28") MODE="$MODE / "$(band 28 "");;
+					*"32") MODE="$MODE / "$(band 32 "");;
+					*"38") MODE="$MODE / "$(band 38 "");;					
 					*) MODE="$MODE / B${T}";;
 				esac
 				MODE=$(echo $MODE | sed "s/LTE_A/LTE-A |/g" | sed 's,/,+,')


### PR DESCRIPTION
Hi @4IceG,

let me know if you can add these changes to your master code, so we can know when MF289F modem is using B28, B32 and B38 bands.

Thanks!