### PR TITLE
Fix B28/32/38 band show

### DIFF
--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo-addon/19d21432
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo-addon/19d21432
@@ -67,7 +67,7 @@ case "$MODE_NUM" in
                                 *"1") MODE="${MODE/LTE/LTE_A} / "$(band 1 "");;
                                 *"3") MODE="${MODE/LTE/LTE_A} / "$(band 3 "");;
                                 *"7") MODE="${MODE/LTE/LTE_A} / "$(band 7 "");;
-                                *"8") MODE="${MODE/LTE/LTE_A} / "$(band 8 "");;
+                                *"^8") MODE="${MODE/LTE/LTE_A} / "$(band 8 "");;
                                 *"20") MODE="${MODE/LTE/LTE_A} / "$(band 20 "");;
                                 *"28") MODE="${MODE/LTE/LTE_A} / "$(band 28 "");;
                                 *"32") MODE="${MODE/LTE/LTE_A} / "$(band 32 "");;
@@ -80,7 +80,7 @@ case "$MODE_NUM" in
                                         *"1") MODE="$MODE / "$(band 1 "");;
                                         *"3") MODE="$MODE / "$(band 3 "");;
                                         *"7") MODE="$MODE / "$(band 7 "");;
-                                        *"8") MODE="$MODE / "$(band 8 "");;
+                                        *"^8") MODE="$MODE / "$(band 8 "");;
                                         *"20") MODE="$MODE / "$(band 20 "");;
                                         *"28") MODE="$MODE / "$(band 28 "");;
                                         *"32") MODE="$MODE / "$(band 32 "");;
@@ -95,7 +95,7 @@ case "$MODE_NUM" in
                                         *"1") MODE="$MODE / "$(band 1 "");;
                                         *"3") MODE="$MODE / "$(band 3 "");;
                                         *"7") MODE="$MODE / "$(band 7 "");;
-                                        *"8") MODE="$MODE / "$(band 8 "");;
+                                        *"^8") MODE="$MODE / "$(band 8 "");;
                                         *"20") MODE="$MODE / "$(band 20 "");;
                                         *"28") MODE="$MODE / "$(band 28 "");;
                                         *"32") MODE="$MODE / "$(band 32 "");;

--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo-addon/19d21485
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo-addon/19d21485
@@ -105,7 +105,7 @@ case "$MODE_NUM" in
 				*"1") MODE="${MODE/LTE/LTE_A} / "$(band 1 "");;
 				*"3") MODE="${MODE/LTE/LTE_A} / "$(band 3 "");;
 				*"7") MODE="${MODE/LTE/LTE_A} / "$(band 7 "");;
-				*"8") MODE="${MODE/LTE/LTE_A} / "$(band 8 "");;
+				*"^8") MODE="${MODE/LTE/LTE_A} / "$(band 8 "");;
 				*"20") MODE="${MODE/LTE/LTE_A} / "$(band 20 "");;
 				*"28") MODE="${MODE/LTE/LTE_A} / "$(band 28 "");;
 				*"32") MODE="${MODE/LTE/LTE_A} / "$(band 32 "");;
@@ -118,7 +118,7 @@ case "$MODE_NUM" in
 					*"1") MODE="$MODE / "$(band 1 "");;
 					*"3") MODE="$MODE / "$(band 3 "");;
 					*"7") MODE="$MODE / "$(band 7 "");;
-					*"8") MODE="$MODE / "$(band 8 "");;
+					*"^8") MODE="$MODE / "$(band 8 "");;
 					*"20") MODE="$MODE / "$(band 20 "");;
 					*"28") MODE="$MODE / "$(band 28 "");;
 					*"32") MODE="$MODE / "$(band 32 "");;
@@ -133,7 +133,7 @@ case "$MODE_NUM" in
 					*"1") MODE="$MODE / "$(band 1 "");;
 					*"3") MODE="$MODE / "$(band 3 "");;
 					*"7") MODE="$MODE / "$(band 7 "");;
-					*"8") MODE="$MODE / "$(band 8 "");;
+					*"^8") MODE="$MODE / "$(band 8 "");;
 					*"20") MODE="$MODE / "$(band 20 "");;
 					*"28") MODE="$MODE / "$(band 28 "");;
 					*"32") MODE="$MODE / "$(band 32 "");;

--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh
@@ -13,6 +13,9 @@ band() {
 		7) echo "${2}B7 (2600 MHz)";;
 		8) echo "${2}B8 (900 MHz)";;
 		20) echo "${2}B20 (800 MHz)";;
+                28) echo "${2}B28 (700 MHz)";;
+                32) echo "${2}B32 (1500 MHz)";;
+                38) echo "${2}B38 (2600 MHz)";;		
 		*) echo "$1";;
 	esac
 }


### PR DESCRIPTION
Hi @4IceG,

today I was able to test B28, B32 and B38 band on MF289F modem, I missed some code so i've added it, now bands are displayed correctly. 

Here are some example for B38 and B32:

![IMAGE 2022-08-26 19:24:54](https://user-images.githubusercontent.com/27808541/186959212-5ee9329a-6eb4-4e53-8450-2a75a083713f.jpg)


![IMAGE 2022-08-26 19:25:14](https://user-images.githubusercontent.com/27808541/186959263-1da417c9-f3bb-4eb8-ac9c-48be6770a0eb.jpg)

If you agree please integrate in your branch

thanks :)
