### PR TITLE
Fix unknown rssi for some huawei hilink

### DIFF
--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/hilink/huawei_hilink.sh
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/hilink/huawei_hilink.sh
@@ -61,12 +61,23 @@ then
     PROTO="NCM"
 fi
 
-RSSI=$(getvaluen device-signal rssi)
+RSSI=$(getvalue device-signal rssi)
+if [ "$RSSI" == "&lt;=-113dBm" ]; then
+	RSSI=
+else
+	RSSI=$(echo "$RSSI" | sed 's/[^0-9]//g')
+fi
 if [ -n "$RSSI" ]; then
 	CSQ=$(((-1*RSSI + 113)/2))
 	CSQ_PER=$(($CSQ * 100/31))
 else
 	CSQ_PER=$(getvaluen monitoring-status SignalStrength)
+	if [ -z "$CSQ_PER" ]; then
+		CSQ_PER=$(getvaluen monitoring-status SignalIcon)
+		if [ -n "$CSQ_PER" ]; then
+			CSQ_PER=$((($CSQ_PER * 20) - 19))
+		fi
+	fi
 	if [ -n "$CSQ_PER" ]; then
 		CSQ=$((($CSQ_PER*31)/100))
 	fi


### PR DESCRIPTION
Some Huawei hilink modem would return unknown rssi as `&lt;=-113dBm` or `<=-113dBm` in webui.

The number 19 is to set the lower bound value because it only give a signal range from 1-5. So signal 2 will become 21 for example.