### PR TITLE
Huawei hilink: try to read RSRP, RSRQ, SINR for unknown mode/NOSERVICE

### DIFF
--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/hilink/huawei_hilink.sh
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/hilink/huawei_hilink.sh
@@ -85,6 +85,7 @@ fi
 
 MODEN=$(getvaluen monitoring-status CurrentNetworkType)
 case $MODEN in
+	0)  MODE="NOSERVICE";;
 	1)  MODE="GSM";;
 	2)  MODE="GPRS";;
 	3)  MODE="EDGE";;
@@ -136,7 +137,7 @@ case $MODEN in
 	*)  MODE="-";;
 esac
 
-if [ "x$MODE" = "xLTE" ]; then
+if [ "x$MODE" = "xLTE" ] || [ "x$MODE" = "xNOSERVICE"]; then
 	RSRP=$(getvaluens device-signal rsrp)
 	SINR=$(getvaluens device-signal sinr)
 	RSRQ=$(getvaluens device-signal rsrq)


### PR DESCRIPTION
Sometimes my modem return no service thought RSSI, RSRP, RSRQ and SINR are available. So just try to read them

![Screenshot_20240327-120327_Kiwi Browser](https://github.com/4IceG/luci-app-3ginfo-lite/assets/110870661/8a6aa3ff-744b-4429-a7e3-66fc9cba6025)

