### PR TITLE
fix ash comparison

### DIFF
--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh
@@ -220,7 +220,7 @@ getpath() {
 # --- modemdefine - WAN config ---
 CONFIG=modemdefine
 MODEMZ=$(uci show $CONFIG | grep -o "@modemdefine\[[0-9]*\]\.modem" | wc -l | xargs)
-if [[ $MODEMZ > 1 ]]; then
+if [[ $MODEMZ -gt 1 ]]; then
 	SEC=$(uci -q get modemdefine.@general[0].main_network)
 	fi	
 	if [[ $MODEMZ = "0" ]]; then


### PR DESCRIPTION
Busybox ash does not support `>` as test operator, instead of comparison it responds to it as stdout redirection and thus creates file with name `1` in place where script was started (usually `/`).