### PR TITLE
More comparison fixes

### DIFF
--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh
@@ -223,10 +223,10 @@ MODEMZ=$(uci show $CONFIG | grep -o "@modemdefine\[[0-9]*\]\.modem" | wc -l | xa
 if [[ $MODEMZ -gt 1 ]]; then
 	SEC=$(uci -q get modemdefine.@general[0].main_network)
 	fi	
-	if [[ $MODEMZ = "0" ]]; then
+	if [[ $MODEMZ -eq 0 ]]; then
 	SEC=$(uci -q get 3ginfo.@3ginfo[0].network)
 	fi
-	if [[ $MODEMZ = 1 ]]; then
+	if [[ $MODEMZ -eq 1 ]]; then
 	SEC=$(uci -q get modemdefine.@modemdefine[0].network)
 fi
 
@@ -235,7 +235,7 @@ fi
 		PORIG=$P
 		for DEV in /sys/class/tty/* /sys/class/usbmisc/*; do
 			getpath "/dev/"${DEV##/*/}
-			if [ "x$PORIG" = "x$P" ]; then
+			if [ "x$PORIG" == "x$P" ]; then
 				SEC=$(uci show network | grep "/dev/"${DEV##/*/} | cut -f2 -d.)
 				[ -n "$SEC" ] && break
 			fi
@@ -278,7 +278,7 @@ fi
 # CSQ
 CSQ=$(echo "$O" | awk -F[,\ ] '/^\+CSQ/ {print $2}')
 
-[ "x$CSQ" = "x" ] && CSQ=-1
+[ "x$CSQ" == "x" ] && CSQ=-1
 if [ $CSQ -ge 0 -a $CSQ -le 31 ]; then
 	CSQ_PER=$(($CSQ * 100/31))
 else
@@ -318,7 +318,7 @@ isp_num="$COPS_MCC $COPS_MNC"
 isp_numws="$COPS_MCC$COPS_MNC"
 
 if [[ $COPS =~ ^[0-9]+$ ]]; then
-    if [[ "$COPS" = "$isp_num" || "$COPS" = "$isp_numws" ]]; then
+    if [[ "$COPS" == "$isp_num" || "$COPS" == "$isp_numws" ]]; then
 	if [[ -n "$isp" ]]; then
 		COPS=$(awk -F[\;] '/^'$isp';/ {print $3}' $RES/mccmnc.dat | xargs)
 		LOC=$(awk -F[\;] '/^'$isp';/ {print $2}' $RES/mccmnc.dat)
@@ -360,7 +360,7 @@ fi
 
 T=$(echo "$O" | awk -F[,\ ] '/^\+CPIN:/ {print $0;exit}' | xargs)
 if [ -n "$T" ]; then
-	[ "$T" = "+CPIN: READY" ] || REG=$(echo "$T" | cut -f2 -d: | xargs)
+	[ "$T" == "+CPIN: READY" ] || REG=$(echo "$T" | cut -f2 -d: | xargs)
 fi
 
 T=$(echo "$O" | awk -F[,\ ] '/^\+CME ERROR:/ {print $0;exit}')
@@ -392,7 +392,7 @@ case "$T" in
 esac
 
 # MODE
-if [ -z "$MODE_NUM" ] || [ "x$MODE_NUM" = "x0" ]; then
+if [ -z "$MODE_NUM" ] || [ "x$MODE_NUM" == "x0" ]; then
 	MODE_NUM=$(echo "$O" | awk -F[,] '/^\+COPS/ {print $4;exit}')
 fi
 case "$MODE_NUM" in
@@ -432,7 +432,7 @@ else
 
 if [ -e /usr/bin/sms_tool ]; then
 	REGOK=0
-	[ "x$REG" = "x1" ] || [ "x$REG" = "x5" ] || [ "x$REG" = "x6" ] || [ "x$REG" = "x7" ] && REGOK=1
+	[ "x$REG" == "x1" ] || [ "x$REG" == "x5" ] || [ "x$REG" == "x6" ] || [ "x$REG" == "x7" ] && REGOK=1
 	VIDPID=$(getdevicevendorproduct $DEVICE)
 	if [ -e "$RES/modem/$VIDPID" ]; then
 		case $(cat /tmp/sysinfo/board_name) in


### PR DESCRIPTION
Same as with `>`, but `=` now. It should be `==`, because `=` is an assignment operator and so no comparisons happened in that code before fix. And for integers it will be better to user `-eq` instead of `==`.