### PR TITLE
Use alternative method to get temperature on Fibocom FM350

### DIFF
--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/usb/0e8d7126
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/usb/0e8d7126
@@ -282,8 +282,8 @@ OCC=$(sms_tool -d $DEVICE at "AT+ICCID")
 NR_ICCID=$(echo "$OCC" | awk -F [,:] '/\+ICCID:/ {print $2}' | xargs)
 
 # Temp
-OT=$(sms_tool -d $DEVICE at "AT+GTSENRDTEMP=1")
-TM=$(echo "$OT" | awk -F, '/\+GTSENRDTEMP:/{printf "%.1f", $2/1000}' | xargs)
+OT=$(sms_tool -d "$DEVICE" at "AT+ETHERMAL?")
+TM=$(echo "$OT" | awk -F, '/\+ETHERMAL:/{ sum+=$2; count++ } END { if(count > 0) { printf "%.1f", sum/count } else { print 0 } }' | xargs)
 if [ -n "$TM" ]; then
   TEMP="$TM &deg;C"
 fi

--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/usb/0e8d7127
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/usb/0e8d7127
@@ -282,8 +282,8 @@ OCC=$(sms_tool -d $DEVICE at "AT+ICCID")
 NR_ICCID=$(echo "$OCC" | awk -F [,:] '/\+ICCID:/ {print $2}' | xargs)
 
 # Temp
-OT=$(sms_tool -d $DEVICE at "AT+GTSENRDTEMP=1")
-TM=$(echo "$OT" | awk -F, '/\+GTSENRDTEMP:/{printf "%.1f", $2/1000}' | xargs)
+OT=$(sms_tool -d "$DEVICE" at "AT+ETHERMAL?")
+TM=$(echo "$OT" | awk -F, '/\+ETHERMAL:/{ sum+=$2; count++ } END { if(count > 0) { printf "%.1f", sum/count } else { print 0 } }' | xargs)
 if [ -n "$TM" ]; then
   TEMP="$TM &deg;C"
 fi


### PR DESCRIPTION
I am opening this pull request to modify the method used to retrieve temperature data because the current command occasionally causes the FIBOCOM device to randomly stop transmitting thermal readings. For example:

![image](https://github.com/user-attachments/assets/a0c5aab8-a899-42a0-bf51-8c62ab2f351f)

Instead, using the other command seems to work without giving any problems.

![image](https://github.com/user-attachments/assets/97f9e232-b1f5-461b-a136-62d12630e712)
