### PR TITLE
workaround for malformed cops reply

### DIFF
--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh
@@ -404,7 +404,7 @@ esac
 
 # MODE
 if [ -z "$MODE_NUM" ] || [ "x$MODE_NUM" == "x0" ]; then
-	MODE_NUM=$(echo "$O" | awk -F[,] '/^\+COPS/ {print $4;exit}' | xargs)
+	MODE_NUM=$(echo "$O" | awk -F[,] '/^\+COPS: 0,2/ {print $4;exit}' | xargs)
 fi
 case "$MODE_NUM" in
 	2*) MODE="UMTS";;


### PR DESCRIPTION
Some operator names contain carriage return and/or newline characters:

```
root@WazonWrt:~# sms_tool -d /dev/ttyUSB2 at "AT+COPS=3,0;+COPS?" | sed 's/\r/\\r/g'
AT+COPS=3,0;+COPS?\r\r
+COPS: 0,0,"Mobile Vikings\r\r
",7\r
\r
```

Since commit 51d8df1 added primitive sanitization, this no longer crashes the app.

However, this will still cause issues with mode recognition:
https://github.com/4IceG/luci-app-3ginfo-lite/blob/51d8df1aa1f3ab3fb1e711503619a77848a8233c/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh#L407

And consequently, modem scripts won't be able to get cell id and signal data.

Sanitizing the output can be tricky. Previously, I added a line to remove `\r\r\n` sequences, but this approach is not universally applicable and could potentially break compatibility with other devices.

To resolve this, we can bypass the issue entirely by using the response from the other COPS command we've already sent.