### PR TITLE
Add support for Fibocom FG621-EA (in NCM mode)

### DIFF
--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/3ginfo.sh
@@ -197,7 +197,7 @@ fi
 
 O=""
 if [ -e /usr/bin/sms_tool ]; then
-	O=$(sms_tool -D -d $DEVICE at "AT+CPIN?;+CSQ;+COPS=3,0;+COPS?;+COPS=3,2;+COPS?;+CREG=2;+CREG?")
+	O=$(sms_tool -D -d $DEVICE at "AT+CSQ;+COPS=3,0;+COPS?;+COPS=3,2;+COPS?;+CREG=2;+CREG?;+CPIN?")
 else
 	O=$(gcom -d $DEVICE -s $RES/info.gcom 2>/dev/null)
 fi
@@ -421,6 +421,7 @@ case "$MODE_NUM" in
 	5*) MODE="HSUPA";;
 	6*) MODE="HSPA";;
 	7*) MODE="LTE";;
+	16*) MODE="LTE";; # returned by FG621 in LTE-A mode
 	 *) MODE="-";;
 esac
 

--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/usb/2cb70a05
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/usb/2cb70a05
@@ -1,0 +1,187 @@
+# Fibocom modems with ProdID=0a05
+# FG621-EA in NCM mode (LTE CAT6)
+# based on 2cb70105
+
+O=$(sms_tool -d $DEVICE at "AT+GTCCINFO?;+GTCAINFO?")
+
+if [ "x$MODE" = "xLTE" ]; then
+	if [[ "$O" == *"SCC"* ]]; then
+		MODE="LTE_A"
+	fi
+	T1=$(echo "$O" | grep -A 3 'LTE service cell' | grep '1,4,'${COPS_MCC}','${COPS_MNC}',')
+	if [ -n "$T1" ]; then
+		T=$(echo "$T1" | awk -F, '{print $5}')
+		if [ -n "$T" ]; then
+			T_DEC=$(printf "%d" "0x$T")
+			T_HEX=$T
+			LAC_DEC=""
+			LAC_HEX=""
+		fi
+		T=$(echo "$T1" | awk -F, '{print $7}')
+		if [ -n "$T" ]; then
+			EARFCN=$T
+		fi
+		T=$(echo "$T1" | awk -F, '{print $8}')
+		if [ -n "$T" ]; then
+			PCI=$T
+		fi
+		T=$(echo "$T1" | awk -F, '{print $9}')
+		if [ -n "$T" ]; then
+			#T=$((T - 100)) # the primary band number is reported directly
+			MODE="$MODE | $(band4g $T)"
+			PBAND="$(band4g $T "")"
+		fi
+		T=$(echo "$T1" | awk -F, '{print $11}')
+		if [ -n "$T" ]; then
+			T2=$(echo "$T" | awk '{printf "%0.1f", $1/2 }')
+			SINR=$T2
+		fi
+		T=$(echo "$T1" | awk -F, '{print $13}')
+		if [ -n "$T" ]; then
+			RSRP=$((T - 141))
+		fi
+		T=$(echo "$T1" | awk -F, '{print $14}')
+		if [ -n "$T" ]; then
+			T2=$(echo "$T" | awk '{printf "%0.1f", ($1-34)/2-3 }')
+			RSRQ=$T2
+		fi
+
+		if [ -n "$CSQ" ]; then
+			RSSI=$((2 * $CSQ -113))
+		fi
+
+
+	fi
+
+	T=$(echo "$O" | awk -F[:,] '/^PCC/{print $3}')
+	if [ -n "$T" ]; then
+		PCI=$T
+	fi
+	T=$(echo "$O" | awk -F[:,] '/^PCC/{print $4}')
+	if [ -n "$T" ]; then
+		EARFCN=$T
+	fi
+
+IFS="
+"
+
+	IDX=1
+	LINES=$(echo "$O" | grep -E "^SCC[0-9]:2")
+	for LINE in $LINES; do
+		T=$(echo "$LINE" | awk -F[:,] '/^SCC'$IDX':2,./{print $4}')
+		T=$((T - 100)) # secondary band is still incremended
+		
+		T2=$(band4g $T)
+		MODE="$MODE / $T2"
+
+		if [ -n "$T" ]; then
+
+			case $IDX in
+			"1") S1BAND="$T2";;
+			"2") S2BAND="$T2";;
+			"3") S3BAND="$T2";;
+			"4") S4BAND="$T2";;
+			*);;
+			esac
+			
+		fi
+					
+		T=$(echo "$LINE" | awk -F[:,] '/^SCC'$IDX':2,./{print $5}')
+		if [ -n "$T" ]; then
+
+			case $IDX in
+			"1") S1PCI="$T";;
+			"2") S2PCI="$T";;
+			"3") S3PCI="$T";;
+			"4") S4PCI="$T";;
+			*);;
+			esac
+
+		fi
+		
+		T=$(echo "$LINE" | awk -F[:,] '/^SCC'$IDX':2,./{print $6}')
+		if [ -n "$T" ]; then
+
+			case $IDX in
+			"1") S1EARFCN="$T";;
+			"2") S2EARFCN="$T";;
+			"3") S3EARFCN="$T";;
+			"4") S4EARFCN="$T";;
+			*);;
+			esac
+
+		fi
+		IDX=$((IDX + 1))
+	done
+
+fi
+
+MODE=$(echo $MODE | sed "s/LTE_A /LTE-A /g" | sed 's,/,+,')
+
+# Modem
+OA=$(sms_tool -d $DEVICE at "AT+CGMM?")
+MODELA=$(echo "$OA" | awk -F [:,] '/\+CGMM/{print $2}' | xargs)
+OB=$(sms_tool -d $DEVICE at "AT+CGMI?")
+MODELB=$(echo "$OB" | awk -F [:,] '/\+CGMI/{print $2}' | xargs)
+MODELBCUT=$(echo $MODELB | sed s/"Wireless Inc."//)
+MODEL="$MODELBCUT $MODELA"
+
+OF=$(sms_tool -d $DEVICE at "AT+GMR?")
+FW=$(echo "$OF" | awk -F[,:] '/\+GMR:/ {print $2}' | xargs)
+
+# International Mobile Equipment Identity (IMEI)
+OAA=$(sms_tool -d $DEVICE at "AT+CGSN?")
+NR_IMEI=$(echo "$OAA" | awk -F[,:] '/\+CGSN:/ {print $2}' | xargs)
+
+# International Mobile Subscriber Identity (IMSI)
+OBB=$(sms_tool -d $DEVICE at "AT+CIMI?")
+NR_IMSI=$(echo "$OBB" | awk -F [,:] '/\+CIMI:/ {print $2}' | xargs)
+
+# Integrated Circuit Card Identifier (ICCID)
+OCC=$(sms_tool -d $DEVICE at "AT+ICCID")
+NR_ICCID=$(echo "$OCC" | awk -F [,:] '/\+ICCID:/ {print $2}' | xargs)
+
+# Temp
+OT=$(sms_tool -d $DEVICE at "AT+MTSM=1")
+TM=$(echo "$OT" | awk '/\+MTSM:/{print $2}')
+if [ -n "$TM" ]; then
+	TEMP="$TM &deg;C"
+fi
+
+# Protocol
+# DRIVER=QMI_WWAN & DRIVER=CDC_MBIM & DRIVER=CDC_ETHER
+
+TTY=$(basename $DEVICE)
+devpath=$(readlink -f /sys/class/tty/$TTY/device)
+BASE=$(readlink -f ${devpath%/*/*})
+
+NETIF=$(for a in /sys/class/net/*; do readlink -f $a; done | grep "$BASE")
+NETDRV=$(basename $(readlink -f $NETIF/../../driver))
+
+case $NETDRV in
+	"qmi_wwan")
+		PROTO="QMI";;
+	"cdc_mbim")
+		PROTO="MBIM";;
+	"cdc_ether")
+		 PROTO="ECM";;
+	"cdc_ncm")
+		 PROTO="NCM";;
+esac
+
+
+PV=$(cat /sys/kernel/debug/usb/devices 2>/dev/null)
+PVCUT=$(echo $PV | awk -F 'Vendor=2cb7 ProdID=0a05' '{print $2}' | cut -c-1290)
+if echo "$PVCUT" | grep -q "Driver=qmi_wwan"
+then
+    PROTO="qmi"
+elif echo "$PVCUT" | grep -q "Driver=cdc_mbim"
+then
+    PROTO="mbim"
+elif echo "$PVCUT" | grep -q "Driver=cdc_ether"
+then
+    PROTO="ecm"
+elif echo "$PVCUT" | grep -q "Driver=cdc_ncm"
+then
+    PROTO="ncm"
+fi


### PR DESCRIPTION
Adds support for Fibocom FG621-EA (in NCM mode)
This modem is used in:
TP-Link TL-MR500v1
Asus 4G-AX56

The data parsing was adapted from the existing `2cb70105`, however the *FG621-EA* is quirky (read that as *broken*) on how it handles `AT+CPIN?` queries and the only workaround I could find was to move the `CPIN` command at the end of the AT queries list in `3ginfo.sh`.
I made a quick check of this change with a Qualcomm EP06 modem and it doesn't appear to have broken it, but I can't speak for all other supported modems. 

Additionally, the *FG621-EA* reports an odd value of `16` for `MODE` when it's in LTE-A mode (2 CA), which needs to be handled by `3ginfo.sh`. 

<img width="1373" height="1489" alt="3ginfo-CA-1 7" src="https://github.com/user-attachments/assets/c6448e17-999c-45a7-b59b-6df12c528104" />
