### PR TITLE
Fix syntax error and improve signal percentage calculation for Fibocom FM350-GL (0e8d:7127)

### DIFF
--- a/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/usb/0e8d7127
+++ b/luci-app-3ginfo-lite/root/usr/share/3ginfo-lite/modem/usb/0e8d7127
@@ -93,7 +93,7 @@ if [ -n "$T1" ]; then
     esac
   fi
   if [ -n "$CSQ" ]; then
-    RSSI=$((2 * $CSQ -113))
+    RSSI=$((2 * $CSQ - 113))
   fi
 fi
 
@@ -152,7 +152,6 @@ elif [ -n "$T_5G_PBAND" ]; then
   PCI="$T_5G_PCI"
   EARFCN="$T_5G_EARFCN"
 fi
-
 
 IFS="
 "
@@ -258,13 +257,21 @@ if [ -z "$T_MODE" ]; then
   fi
 fi
 
-# Modem data forcing
-if [ "$CSQ" = "0" ]; then
-$CSQ="1"
-$CSQ_PER="10"
+# Fixed Modem Data & Signal percentage calculation based on RSRP
+if [ "$CSQ" = "0" ] || [ -z "$CSQ" ]; then
+  CSQ="1"
 fi
 
-# Modem
+if [ -n "$RSRP" ] && [ "$RSRP" != "-" ]; then
+  MAX_RSRP=-44
+  MIN_RSRP=-140
+  TMP_RSRP=$RSRP
+  if [ "$TMP_RSRP" -gt "$MAX_RSRP" ]; then TMP_RSRP=$MAX_RSRP; fi
+  if [ "$TMP_RSRP" -lt "$MIN_RSRP" ]; then TMP_RSRP=$MIN_RSRP; fi
+  CSQ_PER=$(( (TMP_RSRP - MIN_RSRP) * 100 / (MAX_RSRP - MIN_RSRP) ))
+fi
+
+# Modem Info
 OA=$(sms_tool -d $DEVICE at "AT+CGMM?")
 MODELA=$(echo "$OA" | awk -F [:,] '/\+CGMM/{print $2}' | xargs)
 OB=$(sms_tool -d $DEVICE at "AT+CGMI?")
@@ -295,8 +302,6 @@ if [ -n "$TM" ]; then
 fi
 
 # Protocol
-# DRIVER=QMI_WWAN & DRIVER=CDC_MBIM & DRIVER=CDC_ETHER
-
 TTY=$(basename $DEVICE)
 devpath=$(readlink -f /sys/class/tty/$TTY/device)
 BASE=$(readlink -f ${devpath%/*/*})
@@ -310,7 +315,7 @@ case $NETDRV in
   "cdc_mbim")
     PROTO="mbim";;
   "cdc_ether")
-     PROTO="ecm";;
+    PROTO="ecm";;
    "rndis_host")
-     PROTO="ncm";;
+    PROTO="ncm";;
 esac


### PR DESCRIPTION
### Description

This PR addresses two issues in the modem script for Fibocom FM350-GL (`0e8d7127`):

1. **Syntax error fix:**
   - Fixed an invalid shell variable assignment on lines where `$CSQ="1"` and `$CSQ_PER="10"` were used. In POSIX shell / sh, leading `$` must not be present when assigning a value to a variable. This was causing a `command not found` execution error when `CSQ` equaled `0`.

2. **RSRP-based signal percentage calculation:**
   - Added logic to dynamically calculate `CSQ_PER` (signal percentage) based on the received `RSRP` value (`-140 dBm` to `-44 dBm`).
   - Legacy `AT+CSQ` often reports `0` or outdated values in 4G/5G modes on Fibocom MediaTek-based modules, causing the UI to show `0%` signal despite a active LTE/5G connection. Using RSRP provides accurate signal strength representation in LuCI.

### Changes Made

- Updated `/usr/share/3ginfo-lite/modem/usb/0e8d7127` (and corresponding PCI file if applicable):
  - Fixed syntax for `$CSQ` variable check and assignment.
  - Added range normalization and formula for `CSQ_PER` using `RSRP`.

### How to Test

1. Deploy the updated modem script to `/usr/share/3ginfo-lite/modem/usb/0e8d7127`.
2. Run `/usr/share/3ginfo-lite/3ginfo.sh` manually or check the LuCI interface.
3. Verify that no shell assignment errors occur when `CSQ` is `0`, and signal percentage matches actual RSRP values.